### PR TITLE
Fixing kitchen syntax error with the addition of the ubuntu box.

### DIFF
--- a/blog/2013/08/06/getting-started-writing-chef-cookbooks-the-berkshelf-way-part3/index.html
+++ b/blog/2013/08/06/getting-started-writing-chef-cookbooks-the-berkshelf-way-part3/index.html
@@ -492,12 +492,12 @@ testing, in addition to CentOS 6.4.</p>
 <p>Edit <code>.kitchen.yml</code> and add a reference to a Ubuntu 12.04 basebox alongside
 the existing CentOS 6.4 basebox in the <code>platforms</code> stanza:</p>
 
-<pre><code>-name: ubuntu-12.04
- driver_config:
-   box: misheska-ubuntu1204
-   box_url: https://s3-us-west-2.amazonaws.com/misheska/vagrant/virtualbox/misheska-ubuntu1204.box
-   network:
-   - ["private_network", {ip: "33.33.33.11"}]
+<pre><code>- name: ubuntu-12.04
+  driver_config:
+    box: misheska-ubuntu1204
+    box_url: https://s3-us-west-2.amazonaws.com/misheska/vagrant/virtualbox/misheska-ubuntu1204.box
+    network:
+    - ["private_network", {ip: "33.33.33.11"}]
 </code></pre>
 
 <div class="bogus-wrapper"><notextile><figure class="code"><figcaption><span>myface/.kitchen.yml </span></figcaption>


### PR DESCRIPTION
I was following your tutorial and copied the following section of code into my .kitchen.yml and it caused a syntax error. It appears the error was due to a missing space between `-` and `name`. At least that seemed to fix my issue. I thought I would share this with you.

Thank you for your great tutorial.
