### PR TITLE
Apparently, RSpec.configuration.os is now a hash and we need to referenc...

### DIFF
--- a/source/_posts/2013-08-06-getting-started-writing-chef-cookbooks-the-berkshelf-way-part3.markdown
+++ b/source/_posts/2013-08-06-getting-started-writing-chef-cookbooks-the-berkshelf-way-part3.markdown
@@ -865,8 +865,8 @@ describe 'MyFace webserver' do
   end
 
   it 'should be running the httpd server' do
-    case RSpec.configuration.os
-    when "Debian"
+    case RSpec.configuration.os[:family]
+    when "Ubuntu"
       expect(service 'apache2').to be_running
       expect(service 'apache2').to be_enabled
     else


### PR DESCRIPTION
...e the :family key explicitly.  Additionally, updated the case statement to look for Ubuntu since we're using an Ubuntu instance in the tutorial.

After these updates, kitchen verify will complete without errors.
